### PR TITLE
fix open file encode error

### DIFF
--- a/cpp2python.py
+++ b/cpp2python.py
@@ -285,7 +285,7 @@ def process_file(in_filename, out_filename):
     """
     generator - outputs processed file
     """
-    with open(in_filename, 'r') as file:
+    with open(in_filename, 'r', encoding='utf-8') as file:
         lines = file.readlines()  # probably would die on sources more than 100 000 lines :D
     with open(out_filename, 'w+') as file:
         for line in lines:


### PR DESCRIPTION
fix read utf-8 file in windows10 read to gbk encode.